### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ For regular Emacs users, well... you probably know how to install packages.
 To use the pdf.tocgen functionality that software has to be installed (see
 [[https://krasjet.com/voice/pdf.tocgen/]]). For the other remaining functionality
 the package requires ~pdftotext~ (part of poppler-utils), ~pdfoutline~ (part of
-[[https://launchpad.net/ubuntu/bionic/+package/fntsample][fntsample]]) and ~djvused~ (part of [[http://djvu.sourceforge.net/][http://djvu.sourceforge.net/]]) command line
+[[https://launchpad.net/ubuntu/bionic/+package/fntsample][fntsample]] or from [[https://github.com/yutayamamoto/pdfoutline][Github]] (not from Pypi as the package seems broken)) and ~djvused~ (part of [[http://djvu.sourceforge.net/][http://djvu.sourceforge.net/]]) command line
 utilities to be available. Extraction with OCR requires the ~tesseract~ command
 line utility to be available.
 


### PR DESCRIPTION
add direct link to the original pdfoutline's Github repo, as the one in Pypi seems a broken fork.