### PR TITLE
fix: use a temp variable to store `pdf-filename`

### DIFF
--- a/toc-mode.el
+++ b/toc-mode.el
@@ -325,13 +325,14 @@ The newly created PDF that includes the TOC is written to a file
 named output.pdf and opened in a new buffer. Don't forget to
 rename this new file."
   (interactive)
-  (write-file default-directory)
-  (let* ((message (shell-command-to-string (format "pdftocio '%s' < toc" pdf-filename))))
-    (kill-buffer-if-not-modified (find-file pdf-filename))
-    (when (file-exists-p (concat (file-name-base pdf-filename) "_out.pdf"))
-      (delete-file pdf-filename)
-      (rename-file (concat (file-name-base pdf-filename) "_out.pdf") pdf-filename))
-    (find-file pdf-filename)
+  (let* ((message (shell-command-to-string (format "pdftocio '%s' < toc" pdf-filename)))
+         (filename pdf-filename))
+    (write-file default-directory)
+    (kill-buffer-if-not-modified (find-file filename))
+    (when (file-exists-p (concat (file-name-base filename) "_out.pdf"))
+      (delete-file filename)
+      (rename-file (concat (file-name-base filename) "_out.pdf") filename))
+    (find-file filename)
     (unless (string= message "")
       (message (concat "The pdftocio command returned the following message: \n\n" message)))))
 


### PR DESCRIPTION
The buffer-local variable `pdf-filename` will become `nil` after `(write-file default-directory)`, so it's better to use a temp variable to store its value.